### PR TITLE
Update install libcurl3 and libcurl4 together.txt

### DIFF
--- a/how-to/install libcurl3 and libcurl4 together.txt
+++ b/how-to/install libcurl3 and libcurl4 together.txt
@@ -1,8 +1,9 @@
 after a simple search, you will find this
-https://launchpad.net/~xapienz/+archive/ubuntu/curl34
+https://launchpad.net/~andykimpe/+archive/ubuntu/curl
 
 How to install?
 
-sudo add-apt-repository ppa:xapienz/curl34
+sudo add-apt-repository ppa:andykimpe/curl
 sudo apt-get update
+sudo apt-get -y dist-upgrade
 sudo apt-get install libcurl4 curl


### PR DESCRIPTION
hi xapienz does not keep its deposit up to date

and you can see it here

https://launchpad.net/~xapienz/+archive/ubuntu/curl34/+packages

bionic and focal and non-existent jammy

the one I updated you there for the 3 lts

https://launchpad.net/~andykimpe/+archive/ubuntu/curl/+packages

libcurl3 and libcurl4 support

works on ubuntu LTS version
18.04
20.04
22.04